### PR TITLE
Fix code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -178,11 +178,13 @@ module.exports = class Ethermine {
       })
     }
     setAPIurl(url = 'https://api.ethermine.org', callback){
-      let validapi = ['https://api-ergo.flypool.org', 'https://api-etc.ethermine.org', 'https://api-zcash.flypool.org', 'https://api-ycash.flypool.org', 'https://api-beam.flypool.org', 'https://api-ravencoin.flypool.org', 'https://api.ethpool.org'];
-      if (validapi.indexOf(url) > -1) {
+      const urlLib = require('url');
+      let validHosts = ['api-ergo.flypool.org', 'api-etc.ethermine.org', 'api-zcash.flypool.org', 'api-ycash.flypool.org', 'api-beam.flypool.org', 'api-ravencoin.flypool.org', 'api.ethpool.org'];
+      let parsedUrl = urlLib.parse(url);
+      if (validHosts.includes(parsedUrl.host)) {
         this.apiurl = url;
         callback(false, 'API URL set to: ' + url);
-      }else{
+      } else {
         callback(true, 'API not supported');
       }
     }


### PR DESCRIPTION
Fixes [https://github.com/Wbaker7702/ethermine-api/security/code-scanning/1](https://github.com/Wbaker7702/ethermine-api/security/code-scanning/1)

To fix the problem, we need to parse the URL and check its host value against a whitelist of allowed hosts. This ensures that the check handles arbitrary subdomain sequences correctly and prevents malicious URLs from bypassing the validation.

The best way to fix the problem without changing existing functionality is to use the `url` module to parse the URL and then check the host against the whitelist. We will modify the `setAPIurl` method to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
