### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,5 +1,8 @@
 name: Node.js Package Publish - Master
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/ethermine-api/security/code-scanning/4](https://github.com/Wbaker7702/ethermine-api/security/code-scanning/4)

To fix this, explicitly restrict `GITHUB_TOKEN` permissions for the workflow to the least required. For these jobs, reading repository contents is sufficient (for `actions/checkout` and general CI), and they do not need to write to the repository or manage issues, PRs, etc. The npm publish operation uses `NODE_AUTH_TOKEN` and does not require `GITHUB_TOKEN` write access.

The best fix is to add a `permissions:` block at the workflow root (just under `name:` and before `on:`) that sets `contents: read`. This applies to all jobs unless overridden, which keeps the configuration simple and maintains existing functionality: tests and npm publishing will continue to work, while the implicitly generated `GITHUB_TOKEN` will be restricted to read-only repo contents. No additional imports, methods, or other definitions are needed since this is a YAML configuration change only.

Concretely:
- Edit `.github/workflows/npm.yml`.
- Insert a `permissions:` section after line 1 (the `name:` line) and before the `on:` block.
- Set the minimal permission: `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
